### PR TITLE
feat: add task management buttons

### DIFF
--- a/calendar-app/src/app/app.html
+++ b/calendar-app/src/app/app.html
@@ -1,6 +1,6 @@
 <div class="app-root">
 
-  <h1 class="space-header" routerLink="">{{ title }}</h1>
+  <h1 class="app-header" routerLink="">{{ title }}</h1>
 
   <div class="split-container">
     <app-sidebar-component [user]="user()" />

--- a/calendar-app/src/app/app.scss
+++ b/calendar-app/src/app/app.scss
@@ -1,39 +1,13 @@
-.space-header {
+.app-header {
   width: 100%;
   margin: 0;
-  padding: 2rem 0 2rem 0;
-  background: linear-gradient(120deg, #0f2027 0%, #2c5364 100%);
-  color: #7fdfff;
+  padding: 1.5rem 0;
+  background-color: var(--color-surface);
+  color: var(--color-text);
   text-align: center;
-  font-family: 'Orbitron', 'Segoe UI', Arial, sans-serif;
-  font-size: 2.5rem;
-  letter-spacing: 0.15em;
-  position: relative;
-  box-shadow: 0 4px 24px 0 rgba(44, 83, 100, 0.3);
-  overflow: hidden;
-  text-shadow: 0 0 8px #7fdfff, 0 0 24px #0ff;
-  font-weight: 700;
-  z-index: 1;
-  border: none;
-}
-
-.space-header::before, .space-header::after {
-  content: '';
-  position: absolute;
-  top: 0; left: 0; width: 100%; height: 100%;
-  pointer-events: none;
-  z-index: 0;
-}
-
-.space-header::before {
-  background: radial-gradient(circle at 20% 30%, rgba(255,255,255,0.08) 0, transparent 60%),
-              radial-gradient(circle at 80% 60%, rgba(255,255,255,0.06) 0, transparent 70%),
-              radial-gradient(circle at 50% 80%, rgba(255,255,255,0.04) 0, transparent 80%);
-}
-
-.space-header::after {
-  background-image: repeating-radial-gradient(circle, #fff 0 1px, transparent 1px 100px);
-  opacity: 0.08;
+  font-size: 2rem;
+  font-weight: 600;
+  border-bottom: 1px solid var(--color-border);
 }
 
 .app-root {
@@ -50,8 +24,10 @@
 }
 
 app-sidebar-component {
-  width: 200px;
+  width: 220px;
   flex-shrink: 0;
+  background-color: var(--color-surface);
+  border-right: 1px solid var(--color-border);
 }
 
 app-task-manager-component {

--- a/calendar-app/src/app/components/sidebar-component/sidebar-component.html
+++ b/calendar-app/src/app/components/sidebar-component/sidebar-component.html
@@ -1,17 +1,9 @@
 <div class="sidebar">
-    <div class="standardGap"></div>
-
-    <div class="userProfile">{{user_initials()}}</div>
-    
-    <div class="standardGap"></div>
-
-    <div class="taskManager" routerLink="/taskmanager">
-        <img src="\assets\TaskManagerIcon.png" style="width: 64px; height: 64px;" />
-    </div>
-
-    <div class="standardGap"></div>
-
-    <div class="calendar">
-        <img src="\assets\CalendarIcon.png" style="width: 64px; height: 64px;" />
-    </div>
+  <div class="user-profile">{{ user_initials() }}</div>
+  <div class="nav-button" routerLink="/taskmanager">
+    <img src="assets/TaskManagerIcon.png" width="32" height="32" alt="Task Manager" />
+  </div>
+  <div class="nav-button" routerLink="/calendar">
+    <img src="assets/CalendarIcon.png" width="32" height="32" alt="Calendar" />
+  </div>
 </div>

--- a/calendar-app/src/app/components/sidebar-component/sidebar-component.scss
+++ b/calendar-app/src/app/components/sidebar-component/sidebar-component.scss
@@ -1,33 +1,37 @@
 .sidebar {
-    background-color: grey;
-    height: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 24px 0;
+  gap: 32px;
+  height: 100%;
+  background-color: var(--color-surface);
 }
 
-.standardGap {
-    height: 40px;
+.user-profile {
+  width: 80px;
+  height: 80px;
+  border-radius: 50%;
+  background-color: var(--color-primary);
+  color: #fff;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 24px;
+  font-weight: 600;
 }
 
-.userProfile {
-    // Circle
-    border-radius: 50%;
-    width: 100px;
-    height: 100px;
-    background-color: lightblue;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    margin: 0 auto;
-
-    // Initials inside
-    font-size: 20px;
-    font-family: Arial, sans-serif;
+.nav-button {
+  width: 60px;
+  height: 60px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 16px;
+  cursor: pointer;
+  transition: background-color 0.2s ease;
 }
 
-.taskManager, .calendar {
-    width: 80px;
-    height: 80px;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    margin: 0 auto;
+.nav-button:hover {
+  background-color: rgba(0, 0, 0, 0.05);
 }

--- a/calendar-app/src/app/components/task-manager-component/task-manager-component.scss
+++ b/calendar-app/src/app/components/task-manager-component/task-manager-component.scss
@@ -1,17 +1,16 @@
 .task-manager {
-    background-color: beige;
-    overflow: auto;
-    width: 100%;
-    height: 100%;
+  width: 100%;
+  height: 100%;
+  overflow: auto;
+  background-color: var(--color-surface);
+  border-radius: var(--radius);
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+  padding: 24px;
 }
 
 .task-manager-title {
-    font-size: 1.8rem;
-    font-weight: 600;
-    color: #333;
-    margin-bottom: 16px;
-    padding-left: 12px;
-    padding: 8px 12px;
-    border-radius: 4px;
-    letter-spacing: 0.5px;
+  font-size: 1.5rem;
+  font-weight: 600;
+  color: var(--color-text);
+  margin-bottom: 24px;
 }

--- a/calendar-app/src/app/components/task-manager-component/task-manager-list/task-list-item/task-list-item.html
+++ b/calendar-app/src/app/components/task-manager-component/task-manager-list/task-list-item/task-list-item.html
@@ -20,10 +20,10 @@
 
   <span class="title">{{ task().title }}</span>
   @if (task().deadline) { <span class="deadline"> {{ task().deadline }}</span> }
-  <span class="actions">
-    <button type="button" (click)="modifyTask()">Modify</button>
-    <button type="button" (click)="deleteTask()">Delete</button>
-  </span>
+    <span class="actions">
+      <button type="button" class="modify" (click)="modifyTask()">Modify</button>
+      <button type="button" class="delete" (click)="deleteTask()">Delete</button>
+    </span>
 </div>
 
 @if (expanded() && hasChildren()) {
@@ -33,3 +33,4 @@
     }
   </div>
 }
+

--- a/calendar-app/src/app/components/task-manager-component/task-manager-list/task-list-item/task-list-item.html
+++ b/calendar-app/src/app/components/task-manager-component/task-manager-list/task-list-item/task-list-item.html
@@ -20,6 +20,10 @@
 
   <span class="title">{{ task().title }}</span>
   @if (task().deadline) { <span class="deadline"> {{ task().deadline }}</span> }
+  <span class="actions">
+    <button type="button" (click)="modifyTask()">Modify</button>
+    <button type="button" (click)="deleteTask()">Delete</button>
+  </span>
 </div>
 
 @if (expanded() && hasChildren()) {

--- a/calendar-app/src/app/components/task-manager-component/task-manager-list/task-list-item/task-list-item.scss
+++ b/calendar-app/src/app/components/task-manager-component/task-manager-list/task-list-item/task-list-item.scss
@@ -1,45 +1,71 @@
 :host {
-    display: block;
-    --indent-step: 16px; /* Tweak globally if you like */
-  }
-  
-  .task-row {
-    display: flex;
-    align-items: center;
-    gap: 8px;
-    min-height: 32px;
-  }
-  
-  .twisty {
-    border: none;
-    background: transparent;
-    cursor: pointer;
-    font-size: 14px;
-    width: 20px;
-    line-height: 1;
-    padding: 0;
-  }
-  
-  .tw-empty {
-    width: 20px; /* keeps titles aligned with/without chevrons */
-    display: inline-block;
-  }
-  
-  .title { font-weight: 500; }
-  .deadline { margin-left: 6px; font-size: 12px; opacity: 0.7; }
-  
-  .completed .title {
-    text-decoration: line-through;
-    opacity: 0.6;
-  }
+  display: block;
+  --indent-step: 16px;
+}
 
-  .actions {
-    margin-left: auto;
-    display: flex;
-    gap: 4px;
-  }
+.task-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-height: 40px;
+  background-color: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius);
+  padding: 8px 12px;
+  transition: box-shadow 0.2s ease;
+}
 
-  .actions button {
-    padding: 2px 6px;
-  }
-  
+.task-row:hover {
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.05);
+}
+
+.twisty {
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  font-size: 14px;
+  width: 20px;
+  line-height: 1;
+  padding: 0;
+}
+
+.tw-empty {
+  width: 20px;
+  display: inline-block;
+}
+
+.title {
+  font-weight: 500;
+}
+
+.deadline {
+  margin-left: 6px;
+  font-size: 12px;
+  opacity: 0.7;
+}
+
+.completed .title {
+  text-decoration: line-through;
+  opacity: 0.6;
+}
+
+.actions {
+  margin-left: auto;
+  display: flex;
+  gap: 4px;
+}
+
+.actions button {
+  background-color: transparent;
+  color: var(--color-primary);
+  padding: 4px 8px;
+  border-radius: 8px;
+}
+
+.actions button.delete {
+  color: #ff3b30;
+}
+
+.actions button:hover {
+  background-color: rgba(0, 0, 0, 0.05);
+}

--- a/calendar-app/src/app/components/task-manager-component/task-manager-list/task-list-item/task-list-item.scss
+++ b/calendar-app/src/app/components/task-manager-component/task-manager-list/task-list-item/task-list-item.scss
@@ -32,4 +32,14 @@
     text-decoration: line-through;
     opacity: 0.6;
   }
+
+  .actions {
+    margin-left: auto;
+    display: flex;
+    gap: 4px;
+  }
+
+  .actions button {
+    padding: 2px 6px;
+  }
   

--- a/calendar-app/src/app/components/task-manager-component/task-manager-list/task-list-item/task-list-item.ts
+++ b/calendar-app/src/app/components/task-manager-component/task-manager-list/task-list-item/task-list-item.ts
@@ -1,5 +1,6 @@
-import { Component, computed, input, signal } from '@angular/core';
+import { Component, computed, inject, input, signal } from '@angular/core';
 import { Task } from '../../../../models/TaskList';
+import { TaskManagerService } from '../../../../services/task-manager';
 
 @Component({
   selector: 'app-task-list-item',
@@ -10,6 +11,8 @@ import { Task } from '../../../../models/TaskList';
 export class TaskListItem {
   task = input.required<Task>();
   depth = input<number>(0);
+
+  taskManagerService = inject(TaskManagerService);
 
   expanded = signal<boolean>(true);
 
@@ -23,5 +26,19 @@ export class TaskListItem {
 
   onCompletedChange(evt: Event) {
     this.task().completed = (evt.target as HTMLInputElement).checked;
+  }
+
+  modifyTask() {
+    const title = prompt('New title', this.task().title);
+    const deadline = prompt('New deadline (optional, YYYY-MM-DD)', this.task().deadline) || '';
+    if (title !== null) {
+      this.taskManagerService.modifyTask(this.task().id, { title, deadline });
+    }
+  }
+
+  deleteTask() {
+    if (confirm('Delete task?')) {
+      this.taskManagerService.deleteTask(this.task().id);
+    }
   }
 }

--- a/calendar-app/src/app/components/task-manager-component/task-manager-list/task-manager-list.html
+++ b/calendar-app/src/app/components/task-manager-component/task-manager-list/task-manager-list.html
@@ -1,3 +1,4 @@
+<button type="button" (click)="addTask()">Create Task</button>
 <div class="task-list" role="tree" aria-label="Tasks">
     @for (t of taskData(); track t.id) {
       <app-task-list-item [task]="t" [depth]="0"></app-task-list-item>

--- a/calendar-app/src/app/components/task-manager-component/task-manager-list/task-manager-list.html
+++ b/calendar-app/src/app/components/task-manager-component/task-manager-list/task-manager-list.html
@@ -1,4 +1,4 @@
-<button type="button" (click)="addTask()">Create Task</button>
+<button class="create-btn" type="button" (click)="addTask()">New Task</button>
 <div class="task-list" role="tree" aria-label="Tasks">
     @for (t of taskData(); track t.id) {
       <app-task-list-item [task]="t" [depth]="0"></app-task-list-item>

--- a/calendar-app/src/app/components/task-manager-component/task-manager-list/task-manager-list.scss
+++ b/calendar-app/src/app/components/task-manager-component/task-manager-list/task-manager-list.scss
@@ -1,0 +1,9 @@
+.task-list {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.create-btn {
+  margin-bottom: 16px;
+}

--- a/calendar-app/src/app/components/task-manager-component/task-manager-list/task-manager-list.ts
+++ b/calendar-app/src/app/components/task-manager-component/task-manager-list/task-manager-list.ts
@@ -1,5 +1,4 @@
-import { Component, inject, OnInit, signal } from '@angular/core';
-import { Task } from '../../../models/TaskList';
+import { Component, inject } from '@angular/core';
 import { TaskManagerService } from '../../../services/task-manager';
 import { TaskListItem } from "./task-list-item/task-list-item";
 
@@ -9,12 +8,16 @@ import { TaskListItem } from "./task-list-item/task-list-item";
   templateUrl: './task-manager-list.html',
   styleUrl: './task-manager-list.scss'
 })
-export class TaskManagerList implements OnInit {
+export class TaskManagerList {
 
-  taskData = signal<Task[]>([]);
   taskManagerService = inject(TaskManagerService);
+  taskData = this.taskManagerService.taskManagerItems;
 
-  ngOnInit(): void {
-    this.taskData.set(this.taskManagerService.taskManagerItems);
+  addTask() {
+    const title = prompt('Task title');
+    if (title) {
+      const deadline = prompt('Task deadline (optional, YYYY-MM-DD)') || '';
+      this.taskManagerService.addTask(title, deadline);
+    }
   }
 }

--- a/calendar-app/src/app/services/task-manager.spec.ts
+++ b/calendar-app/src/app/services/task-manager.spec.ts
@@ -13,4 +13,26 @@ describe('TaskManagerService', () => {
   it('should be created', () => {
     expect(service).toBeTruthy();
   });
+
+  it('should add a task', () => {
+    service.addTask('Test Task');
+    expect(service.taskManagerItems().length).toBe(1);
+    expect(service.taskManagerItems()[0].title).toBe('Test Task');
+  });
+
+  it('should modify a task', () => {
+    service.addTask('Old Title');
+    const id = service.taskManagerItems()[0].id;
+    service.modifyTask(id, { title: 'New Title' });
+    expect(service.taskManagerItems()[0].title).toBe('New Title');
+  });
+
+  it('should delete a task', () => {
+    service.addTask('Task 1');
+    service.addTask('Task 2');
+    const id = service.taskManagerItems()[0].id;
+    service.deleteTask(id);
+    expect(service.taskManagerItems().length).toBe(1);
+    expect(service.taskManagerItems()[0].title).toBe('Task 2');
+  });
 });

--- a/calendar-app/src/app/services/task-manager.ts
+++ b/calendar-app/src/app/services/task-manager.ts
@@ -1,20 +1,45 @@
-import { Injectable } from '@angular/core';
+import { Injectable, signal } from '@angular/core';
 import { Task } from '../models/TaskList';
 
 @Injectable({
   providedIn: 'root'
 })
 export class TaskManagerService {
-  taskManagerItems: Array<Task> = [];
+  taskManagerItems = signal<Task[]>([]);
+  private nextId = 1;
   user: string = "";
+
   constructor() { }
 
   updateItems(jsonValue: any) {
-    this.taskManagerItems = this.transformTaskJsonToTasks(jsonValue);
+    const tasks = this.transformTaskJsonToTasks(jsonValue);
+    this.taskManagerItems.set(tasks);
+    this.nextId = tasks.reduce((max, t) => Math.max(max, t.id), 0) + 1;
   }
 
   updateUser(userInput: string) {
     this.user = userInput;
+  }
+
+  addTask(title: string, deadline: string = '') {
+    const newTask: Task = {
+      id: this.nextId++,
+      title,
+      deadline,
+      completed: false,
+      subtasks: []
+    };
+    this.taskManagerItems.update(tasks => [...tasks, newTask]);
+  }
+
+  modifyTask(id: number, updates: Partial<Task>) {
+    this.taskManagerItems.update(tasks =>
+      tasks.map(t => (t.id === id ? { ...t, ...updates } : t))
+    );
+  }
+
+  deleteTask(id: number) {
+    this.taskManagerItems.update(tasks => tasks.filter(t => t.id !== id));
   }
 
   transformTaskJsonToTasks(json: any): Task[] {

--- a/calendar-app/src/styles.scss
+++ b/calendar-app/src/styles.scss
@@ -1,7 +1,41 @@
-/* You can add global styles to this file, and also import other style files */
+/* Global styles for modern, clean appearance */
 
-html, body {
+:root {
+  --color-bg: #f5f5f7;
+  --color-surface: #ffffff;
+  --color-border: #d2d2d7;
+  --color-text: #1d1d1f;
+  --color-primary: #0071e3;
+  --radius: 12px;
+}
+
+html,
+body {
   margin: 0;
   padding: 0;
   box-sizing: border-box;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
+  background-color: var(--color-bg);
+  color: var(--color-text);
+  -webkit-font-smoothing: antialiased;
+}
+
+button {
+  border: none;
+  background-color: var(--color-primary);
+  color: #fff;
+  padding: 0.5rem 1rem;
+  border-radius: var(--radius);
+  font-size: 0.875rem;
+  cursor: pointer;
+  transition: background-color 0.2s ease, transform 0.1s ease;
+}
+
+button:hover {
+  background-color: #005bb5;
+}
+
+button:active {
+  background-color: #004a93;
+  transform: scale(0.97);
 }


### PR DESCRIPTION
## Summary
- add signal-based task store with create, modify, and delete operations
- expose Create Task control in task list component
- allow inline task editing and removal

## Testing
- `npx ng test --watch=false` *(fails: No binary for Chrome browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_68ae53d80c9c8323a94136a65f90c51b