### PR TITLE
Add Flask backend and connect Angular to MySQL API

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -1,0 +1,77 @@
+from flask import Flask, jsonify
+from sqlalchemy import create_engine, Column, Integer, String, Date, Boolean, ForeignKey
+from sqlalchemy.orm import sessionmaker, relationship, declarative_base
+
+# TODO: replace placeholders with actual database credentials
+DATABASE_URL = "mysql+pymysql://<username>:<password>@<host>:<port>/<database>"
+
+engine = create_engine(DATABASE_URL, echo=True, future=True)
+SessionLocal = sessionmaker(bind=engine)
+Base = declarative_base()
+
+class User(Base):
+    __tablename__ = "users"
+    id = Column(Integer, primary_key=True, index=True)
+    username = Column(String(512), nullable=False)
+    password = Column(String(512), nullable=False)
+    first_name = Column(String(512))
+    last_name = Column(String(512))
+    tasks = relationship("Task", back_populates="user")
+
+class Task(Base):
+    __tablename__ = "tasks"
+    id = Column(Integer, primary_key=True, index=True)
+    user_id = Column(Integer, ForeignKey("users.id"), nullable=False)
+    title = Column(String(512))
+    deadline = Column(Date)
+    parent_id = Column(Integer, ForeignKey("tasks.id"))
+    completed = Column(Boolean, default=False)
+    deleted = Column(Boolean, default=False)
+
+    user = relationship("User", back_populates="tasks")
+    subtasks = relationship("Task", backref="parent", remote_side=[id])
+
+def task_to_dict(task):
+    return {
+        "id": task.id,
+        "title": task.title,
+        "deadline": task.deadline.isoformat() if task.deadline else None,
+        "completed": task.completed,
+        "subtasks": []
+    }
+
+def build_task_tree(session, user_id):
+    tasks = session.query(Task).filter_by(user_id=user_id, deleted=False).all()
+    task_map = {t.id: task_to_dict(t) for t in tasks}
+    roots = []
+    for task in tasks:
+        item = task_map[task.id]
+        if task.parent_id and task.parent_id in task_map:
+            task_map[task.parent_id]["subtasks"].append(item)
+        else:
+            roots.append(item)
+    return roots
+
+app = Flask(__name__)
+
+@app.get("/api/users/<int:user_id>")
+def get_user_and_tasks(user_id):
+    session = SessionLocal()
+    user = session.get(User, user_id)
+    if not user:
+        session.close()
+        return jsonify({"error": "User not found"}), 404
+    tasks = build_task_tree(session, user_id)
+    session.close()
+    return jsonify({
+        "user": {
+            "id": user.id,
+            "username": user.username,
+            "first_name": user.first_name,
+            "last_name": user.last_name
+        },
+        "tasks": tasks
+    })
+
+if __name__ == "__main__":
+    app.run(debug=True)

--- a/backend/app.py
+++ b/backend/app.py
@@ -3,7 +3,7 @@ from sqlalchemy import create_engine, Column, Integer, String, Date, Boolean, Fo
 from sqlalchemy.orm import sessionmaker, relationship, declarative_base
 
 # TODO: replace placeholders with actual database credentials
-DATABASE_URL = "mysql+pymysql://<username>:<password>@<host>:<port>/<database>"
+DATABASE_URL = "mysql+pymysql://root:test_root@localhost:3306/calendar"
 
 engine = create_engine(DATABASE_URL, echo=True, future=True)
 SessionLocal = sessionmaker(bind=engine)
@@ -29,7 +29,7 @@ class Task(Base):
     deleted = Column(Boolean, default=False)
 
     user = relationship("User", back_populates="tasks")
-    subtasks = relationship("Task", backref="parent", remote_side=[id])
+    parent_tasks = relationship("Task", backref="parent", remote_side=[id])
 
 def task_to_dict(task):
     return {
@@ -54,7 +54,7 @@ def build_task_tree(session, user_id):
 
 app = Flask(__name__)
 
-@app.get("/api/users/<int:user_id>")
+@app.route("/api/users/<int:user_id>", methods=["GET"])
 def get_user_and_tasks(user_id):
     session = SessionLocal()
     user = session.get(User, user_id)

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,0 +1,3 @@
+Flask
+SQLAlchemy
+PyMySQL

--- a/calendar-app/src/app/app.config.ts
+++ b/calendar-app/src/app/app.config.ts
@@ -1,5 +1,6 @@
 import { ApplicationConfig, provideBrowserGlobalErrorListeners, provideZonelessChangeDetection } from '@angular/core';
 import { provideRouter } from '@angular/router';
+import { provideHttpClient } from '@angular/common/http';
 
 import { routes } from './app.routes';
 import { provideClientHydration, withEventReplay } from '@angular/platform-browser';
@@ -8,6 +9,8 @@ export const appConfig: ApplicationConfig = {
   providers: [
     provideBrowserGlobalErrorListeners(),
     provideZonelessChangeDetection(),
-    provideRouter(routes), provideClientHydration(withEventReplay())
+    provideRouter(routes),
+    provideClientHydration(withEventReplay()),
+    provideHttpClient()
   ]
 };

--- a/calendar-app/src/app/app.html
+++ b/calendar-app/src/app/app.html
@@ -3,8 +3,7 @@
   <h1 class="app-header" routerLink="">{{ title }}</h1>
 
   <div class="split-container">
-    <app-sidebar-component [user]="user()" />
-    <!-- <app-task-manager-component [user]="user()" [taskData]="taskData()" /> -->
+    <app-sidebar-component />
      <app-task-manager-component>
         <router-outlet></router-outlet>
      </app-task-manager-component>

--- a/calendar-app/src/app/app.ts
+++ b/calendar-app/src/app/app.ts
@@ -1,7 +1,6 @@
-import { Component, inject, OnInit, signal } from '@angular/core';
+import { Component, inject, OnInit } from '@angular/core';
 import { RouterLink, RouterOutlet } from '@angular/router';
 import { SidebarComponent } from './components/sidebar-component/sidebar-component';
-import { CalendarComponent } from './components/calendar-component/calendar-component';
 import { TaskManagerComponent } from './components/task-manager-component/task-manager-component';
 import { TaskManagerService } from './services/task-manager';
 
@@ -15,96 +14,9 @@ import { TaskManagerService } from './services/task-manager';
 export class App implements OnInit {
   protected title = 'Plannit';
 
-  user = signal<string>('Rishabh R Jois'); // would pull actual user data from database here
-
-  // call service to retrieve User's tasks and subtasks
-  // this data will be passed in JSON
-  task_json = {
-    "tasks": [
-      {
-        "id": 1,
-        "title": "Calendar App",
-        "deadline": "",
-        "completed": false,
-        "subtasks": [
-          {
-            "id": 2,
-            "title": "Design UI",
-            "deadline": "2025-06-15",
-            "completed": true
-          },
-          {
-            "id": 3,
-            "title": "Implement Database Model",
-            "deadline": "2025-06-22",
-            "completed": false
-          }
-        ]
-      },
-      {
-        "id": 4,
-        "title": "School Project",
-        "deadline": "2025-06-15",
-        "completed": false,
-        "subtasks": [
-          {
-            "id": 5,
-            "title": "Research Topic",
-            "deadline": "2025-06-24",
-            "completed": false,
-            "subtasks": [
-              {
-                "id": 6,
-                "title": "Ask ChatGPT",
-                "deadline": "2025-06-21",
-                "completed": false,
-              },
-              {
-                "id": 7,
-                "title": "Reach out to Professors",
-                "deadline": "2025-06-24",
-                "completed": false,
-                "subtasks": [
-                  {
-                    "id": 8,
-                    "title": "Professor A",
-                    "deadline": "2025-06-22",
-                    "completed": false
-                  },
-                  {
-                    "id": 9,
-                    "title": "Professor B",
-                    "deadline": "2025-06-23",
-                    "completed": false
-                  }
-                ]
-              }
-            ]
-          },
-          {
-            "id": 10,
-            "title": "Complete Assignment",
-            "deadline": "2025-06-26",
-            "completed": false
-          }
-        ]
-      },
-      {
-        "id": 0,
-        "title": "Errands",
-        "deadline": "",
-        "completed": false,
-      }
-    ]
-  }
-
   taskManagerService = inject(TaskManagerService);
 
   ngOnInit(): void {
-    this.taskManagerService.updateItems(this.task_json);
-    this.taskManagerService.updateUser(this.user());
+    this.taskManagerService.loadUserAndTasks(1); // TODO: replace 1 with the logged-in user's ID
   }
-  
-  // taskData = signal<Task[]>(transformTaskJsonToTasks(this.task_json));
-  
 }

--- a/calendar-app/src/app/app.ts
+++ b/calendar-app/src/app/app.ts
@@ -17,6 +17,6 @@ export class App implements OnInit {
   taskManagerService = inject(TaskManagerService);
 
   ngOnInit(): void {
-    this.taskManagerService.loadUserAndTasks(1); // TODO: replace 1 with the logged-in user's ID
+    this.taskManagerService.loadUserAndTasks(0); // TODO: replace 1 with the logged-in user's ID
   }
 }

--- a/calendar-app/src/app/components/sidebar-component/sidebar-component.ts
+++ b/calendar-app/src/app/components/sidebar-component/sidebar-component.ts
@@ -1,5 +1,6 @@
-import { Component, computed, input, signal } from '@angular/core';
+import { Component, computed, inject, input, signal } from '@angular/core';
 import { RouterLink } from '@angular/router';
+import { TaskManagerService } from '../../services/task-manager';
 
 @Component({
   selector: 'app-sidebar-component',
@@ -8,7 +9,9 @@ import { RouterLink } from '@angular/router';
   styleUrl: './sidebar-component.scss'
 })
 export class SidebarComponent {
-  user = input<string>("");
+
+  taskManagerService = inject(TaskManagerService);
+  user = this.taskManagerService.user;
 
   user_initials = computed(() => this.getInitials(this.user()));
 

--- a/calendar-app/src/app/components/task-manager-component/task-manager-component.spec.ts
+++ b/calendar-app/src/app/components/task-manager-component/task-manager-component.spec.ts
@@ -1,4 +1,5 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
 
 import { TaskManagerComponent } from './task-manager-component';
 
@@ -8,7 +9,7 @@ describe('TaskManagerComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [TaskManagerComponent]
+      imports: [TaskManagerComponent, HttpClientTestingModule]
     })
     .compileComponents();
 

--- a/calendar-app/src/app/components/task-manager-component/task-manager-component.ts
+++ b/calendar-app/src/app/components/task-manager-component/task-manager-component.ts
@@ -1,4 +1,4 @@
-import { Component, computed, inject, input, OnInit, signal } from '@angular/core';
+import { Component, computed, inject } from '@angular/core';
 import { Task } from '../../models/TaskList';
 import { TaskManagerService } from '../../services/task-manager';
 import { TaskManagerList } from './task-manager-list/task-manager-list';
@@ -11,9 +11,10 @@ import { TaskManagerList } from './task-manager-list/task-manager-list';
   templateUrl: './task-manager-component.html',
   styleUrl: './task-manager-component.scss'
 })
-export class TaskManagerComponent implements OnInit {
+export class TaskManagerComponent {
 
-  user = signal<string>("");
+  taskManagerService = inject(TaskManagerService);
+  user = this.taskManagerService.user;
 
   firstName = computed(() => this.getPossessiveFirstName(this.user()));
 
@@ -32,12 +33,6 @@ export class TaskManagerComponent implements OnInit {
     const endsWithS = /s$/i.test(firstName);
 
     return endsWithS ? `${firstName}'` : `${firstName}'s`;
-  }
-
-  taskManagerService = inject(TaskManagerService);
-  
-  ngOnInit(): void {
-      this.user.set(this.taskManagerService.user);
   }
 
   /**

--- a/calendar-app/src/app/services/task-manager.spec.ts
+++ b/calendar-app/src/app/services/task-manager.spec.ts
@@ -1,4 +1,5 @@
 import { TestBed } from '@angular/core/testing';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
 
 import { TaskManagerService } from './task-manager';
 
@@ -6,7 +7,9 @@ describe('TaskManagerService', () => {
   let service: TaskManagerService;
 
   beforeEach(() => {
-    TestBed.configureTestingModule({});
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule]
+    });
     service = TestBed.inject(TaskManagerService);
   });
 

--- a/calendar-app/src/app/services/task-manager.ts
+++ b/calendar-app/src/app/services/task-manager.ts
@@ -1,4 +1,5 @@
 import { Injectable, signal } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
 import { Task } from '../models/TaskList';
 
 @Injectable({
@@ -7,9 +8,9 @@ import { Task } from '../models/TaskList';
 export class TaskManagerService {
   taskManagerItems = signal<Task[]>([]);
   private nextId = 1;
-  user: string = "";
+  user = signal<string>('');
 
-  constructor() { }
+  constructor(private http: HttpClient) { }
 
   updateItems(jsonValue: any) {
     const tasks = this.transformTaskJsonToTasks(jsonValue);
@@ -18,7 +19,26 @@ export class TaskManagerService {
   }
 
   updateUser(userInput: string) {
-    this.user = userInput;
+    this.user.set(userInput);
+  }
+
+  loadUserAndTasks(userId: number) {
+    this.http.get<any>(`http://localhost:5000/api/users/${userId}`).subscribe({
+      next: data => {
+        if (data?.user) {
+          const name = [data.user.first_name, data.user.last_name]
+            .filter(Boolean)
+            .join(' ');
+          this.user.set(name || data.user.username);
+        }
+        if (data?.tasks) {
+          this.updateItems({ tasks: data.tasks });
+        }
+      },
+      error: err => {
+        console.error('Failed to load tasks', err);
+      }
+    });
   }
 
   addTask(title: string, deadline: string = '') {


### PR DESCRIPTION
## Summary
- Add Flask server with SQLAlchemy models for users and tasks, exposing `/api/users/<id>` to return task hierarchy
- Provide backend requirements
- Enable Angular HttpClient and service method to load user and tasks from the Flask API
- Adjust components and specs to use new service and HTTP testing utilities

## Testing
- `npm test -- --watch=false` *(fails: No binary for Chrome browser)*

------
https://chatgpt.com/codex/tasks/task_e_68b1024f3288832388bbc711038974b0