### PR TITLE
feat: allow saving tasks and nested subtasks

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -1,4 +1,5 @@
 from flask import Flask, jsonify, request
+from flask_cors import CORS
 from sqlalchemy import create_engine, Column, Integer, String, Date, Boolean, ForeignKey
 from sqlalchemy.orm import sessionmaker, relationship, declarative_base
 from datetime import datetime
@@ -54,6 +55,7 @@ def build_task_tree(session, user_id):
     return roots
 
 app = Flask(__name__)
+CORS(app)
 
 @app.route("/api/users/<int:user_id>", methods=["GET"])
 def get_user_and_tasks(user_id):

--- a/backend/app.py
+++ b/backend/app.py
@@ -1,4 +1,6 @@
 from flask import Flask, jsonify, request
+from flask_cors import CORS
+
 from sqlalchemy import create_engine, Column, Integer, String, Date, Boolean, ForeignKey
 from sqlalchemy.orm import sessionmaker, relationship, declarative_base
 from datetime import datetime
@@ -54,6 +56,7 @@ def build_task_tree(session, user_id):
     return roots
 
 app = Flask(__name__)
+CORS(app)
 
 @app.route("/api/users/<int:user_id>", methods=["GET"])
 def get_user_and_tasks(user_id):

--- a/backend/app.py
+++ b/backend/app.py
@@ -1,6 +1,7 @@
-from flask import Flask, jsonify
+from flask import Flask, jsonify, request
 from sqlalchemy import create_engine, Column, Integer, String, Date, Boolean, ForeignKey
 from sqlalchemy.orm import sessionmaker, relationship, declarative_base
+from datetime import datetime
 
 # TODO: replace placeholders with actual database credentials
 DATABASE_URL = "mysql+pymysql://root:test_root@localhost:3306/calendar"
@@ -72,6 +73,41 @@ def get_user_and_tasks(user_id):
         },
         "tasks": tasks
     })
+
+
+@app.route("/api/users/<int:user_id>/tasks", methods=["POST"])
+def save_tasks(user_id):
+    data = request.get_json(force=True)
+    tasks_data = data.get("tasks", [])
+
+    session = SessionLocal()
+    session.query(Task).filter_by(user_id=user_id).delete()
+    session.commit()
+
+    def persist(task_dict, parent_id=None):
+        deadline = task_dict.get("deadline")
+        deadline_date = (
+            datetime.fromisoformat(deadline).date() if deadline else None
+        )
+        task = Task(
+            user_id=user_id,
+            title=task_dict.get("title"),
+            deadline=deadline_date,
+            parent_id=parent_id,
+            completed=task_dict.get("completed", False),
+            deleted=False,
+        )
+        session.add(task)
+        session.flush()
+        for sub in task_dict.get("subtasks", []):
+            persist(sub, task.id)
+
+    for t in tasks_data:
+        persist(t)
+
+    session.commit()
+    session.close()
+    return jsonify({"status": "success"}), 201
 
 if __name__ == "__main__":
     app.run(debug=True)

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,3 +1,4 @@
 Flask
+Flask-Cors
 SQLAlchemy
 PyMySQL

--- a/calendar-app/src/app/components/task-manager-component/task-manager-list/task-list-item/task-list-item.html
+++ b/calendar-app/src/app/components/task-manager-component/task-manager-list/task-list-item/task-list-item.html
@@ -21,6 +21,7 @@
   <span class="title">{{ task().title }}</span>
   @if (task().deadline) { <span class="deadline"> {{ task().deadline }}</span> }
     <span class="actions">
+      <button type="button" class="subtask" (click)="addSubtask()">Add Subtask</button>
       <button type="button" class="modify" (click)="modifyTask()">Modify</button>
       <button type="button" class="delete" (click)="deleteTask()">Delete</button>
     </span>

--- a/calendar-app/src/app/components/task-manager-component/task-manager-list/task-list-item/task-list-item.ts
+++ b/calendar-app/src/app/components/task-manager-component/task-manager-list/task-list-item/task-list-item.ts
@@ -41,4 +41,13 @@ export class TaskListItem {
       this.taskManagerService.deleteTask(this.task().id);
     }
   }
+
+  addSubtask() {
+    const title = prompt('Subtask title');
+    if (title) {
+      const deadline = prompt('Subtask deadline (optional, YYYY-MM-DD)') || '';
+      this.taskManagerService.addSubtask(this.task().id, title, deadline);
+      this.expanded.set(true);
+    }
+  }
 }

--- a/calendar-app/src/app/components/task-manager-component/task-manager-list/task-manager-list.html
+++ b/calendar-app/src/app/components/task-manager-component/task-manager-list/task-manager-list.html
@@ -1,4 +1,5 @@
 <button class="create-btn" type="button" (click)="addTask()">New Task</button>
+<button class="save-btn" type="button" (click)="saveTasks()">Save</button>
 <div class="task-list" role="tree" aria-label="Tasks">
     @for (t of taskData(); track t.id) {
       <app-task-list-item [task]="t" [depth]="0"></app-task-list-item>

--- a/calendar-app/src/app/components/task-manager-component/task-manager-list/task-manager-list.ts
+++ b/calendar-app/src/app/components/task-manager-component/task-manager-list/task-manager-list.ts
@@ -20,4 +20,8 @@ export class TaskManagerList {
       this.taskManagerService.addTask(title, deadline);
     }
   }
+
+  saveTasks() {
+    this.taskManagerService.saveTasks();
+  }
 }

--- a/calendar-app/src/app/services/task-manager.ts
+++ b/calendar-app/src/app/services/task-manager.ts
@@ -9,6 +9,7 @@ export class TaskManagerService {
   taskManagerItems = signal<Task[]>([]);
   private nextId = 1;
   user = signal<string>('');
+  private currentUserId: number | null = null;
 
   constructor(private http: HttpClient) { }
 
@@ -23,6 +24,7 @@ export class TaskManagerService {
   }
 
   loadUserAndTasks(userId: number) {
+    this.currentUserId = userId;
     this.http.get<any>(`http://localhost:5000/api/users/${userId}`).subscribe({
       next: data => {
         if (data?.user) {
@@ -52,14 +54,36 @@ export class TaskManagerService {
     this.taskManagerItems.update(tasks => [...tasks, newTask]);
   }
 
+  addSubtask(parentId: number, title: string, deadline: string = '') {
+    const newTask: Task = {
+      id: this.nextId++,
+      title,
+      deadline,
+      completed: false,
+      subtasks: []
+    };
+    this.taskManagerItems.update(tasks => this.insertSubtask(tasks, parentId, newTask));
+  }
+
   modifyTask(id: number, updates: Partial<Task>) {
-    this.taskManagerItems.update(tasks =>
-      tasks.map(t => (t.id === id ? { ...t, ...updates } : t))
-    );
+    this.taskManagerItems.update(tasks => this.updateTaskRecursive(tasks, id, updates));
   }
 
   deleteTask(id: number) {
-    this.taskManagerItems.update(tasks => tasks.filter(t => t.id !== id));
+    this.taskManagerItems.update(tasks => this.deleteTaskRecursive(tasks, id));
+  }
+
+  saveTasks() {
+    if (this.currentUserId == null) {
+      console.error('No user loaded');
+      return;
+    }
+    const payload = { tasks: this.taskManagerItems() };
+    this.http.post(`http://localhost:5000/api/users/${this.currentUserId}/tasks`, payload)
+      .subscribe({
+        next: () => console.log('Tasks saved'),
+        error: err => console.error('Failed to save tasks', err)
+      });
   }
 
   transformTaskJsonToTasks(json: any): Task[] {
@@ -78,5 +102,38 @@ export class TaskManagerService {
         ? task.subtasks.map((t: any) => this.transformTask(t))
         : []
     };
+  }
+
+  private insertSubtask(tasks: Task[], parentId: number, subtask: Task): Task[] {
+    return tasks.map(t => {
+      if (t.id === parentId) {
+        return { ...t, subtasks: [...(t.subtasks || []), subtask] };
+      }
+      if (t.subtasks && t.subtasks.length > 0) {
+        return { ...t, subtasks: this.insertSubtask(t.subtasks, parentId, subtask) };
+      }
+      return t;
+    });
+  }
+
+  private updateTaskRecursive(tasks: Task[], id: number, updates: Partial<Task>): Task[] {
+    return tasks.map(t => {
+      if (t.id === id) {
+        return { ...t, ...updates };
+      }
+      if (t.subtasks && t.subtasks.length > 0) {
+        return { ...t, subtasks: this.updateTaskRecursive(t.subtasks, id, updates) };
+      }
+      return t;
+    });
+  }
+
+  private deleteTaskRecursive(tasks: Task[], id: number): Task[] {
+    return tasks
+      .filter(t => t.id !== id)
+      .map(t => ({
+        ...t,
+        subtasks: t.subtasks ? this.deleteTaskRecursive(t.subtasks, id) : []
+      }));
   }
 }


### PR DESCRIPTION
## Summary
- enable backend to persist tasks with new POST /api/users/<id>/tasks endpoint
- allow frontend to add subtasks and save tasks to server
- enhance task service for nested modify/delete operations

## Testing
- `python -m pytest`
- `npm test` *(fails: No binary for Chrome browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_68b59937cc108323a92f3ac6a93e2e47